### PR TITLE
Digitalocean config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ cd /path/to/sentry-ansible-vagrant
 $ vagrant up
 ```
 
-In order to properly access Sentry by its configured hostname (`sentry.server`
+In order to properly access Sentry by its configured hostname (`sentry.local`
 in the `sentry.yml`), you have to add this hostname to your hostsfile.
 On POSIX systems (Linux & OS X), you can add it by doing:
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,32 @@
 # Sentry with Ansible
 
-This playbook provides a complete, hassle-free way to setup [Sentry](https://github.com/getsentry/sentry) on a VPS/Dedicated Server. You can also optionally install it on a Virtual Machine using Vagrant so you can play around with it. This project is a continuation of [sentry-vagrant](https://github.com/DandyDev/sentry-vagrant), using Ansible, because I wanted to try that out as well. Turns out, I like it better than Puppet, so I will maintain this version, and probably not the Puppet version.
+This playbook provides a complete, hassle-free way to setup
+[Sentry](https://github.com/getsentry/sentry) on a VPS/Dedicated Server.
+You can also optionally install it on a Virtual Machine using Vagrant so you
+can play around with it.
+This project is a continuation of
+[sentry-vagrant](https://github.com/DandyDev/sentry-vagrant), using Ansible,
+because I wanted to try that out as well.
+Turns out, I like it better than Puppet, so I will maintain this version, and
+probably not the Puppet version.
 
 What gets installed:
 
-*  PostgreSQL database
-*  NginX webserver/reverse proxy
-*  Python, Pip & VirtualEnv
-*  The latest stable version of **Sentry** and all of its dependencies
+* PostgreSQL database
+* NginX webserver/reverse proxy
+* Python, Pip & VirtualEnv
+* The latest stable version of **Sentry** and all of its dependencies
 
 ## Let's get rolling!
 
-If you want to install Sentry on a VM using Vagrant, you first need to install [Vagrant](http://www.vagrantup.com/) and a Virtual Machine provider of choice ([VirtualBox](https://www.virtualbox.org/) is free and works out of the box with Vagrant). You also need to [install Ansible](http://docs.ansible.com/intro_installation.html).
+If you want to install Sentry on a VM using Vagrant, you first need to install
+[Vagrant](http://www.vagrantup.com/) and a Virtual Machine provider of choice
+([VirtualBox](https://www.virtualbox.org/) is free and works out of the box
+with Vagrant).
+You also need to [install Ansible](http://docs.ansible.com/intro_installation.html).
 
-You can configure your install by modifying the variables in the _sentry.yml_ file before provisioning.
+You can configure your install by modifying the variables in the `sentry.yml`
+file before provisioning.
 
 Then: 
 
@@ -23,7 +36,9 @@ $ cd /path/to/sentry-ansible-vagrant
 $ vagrant up
 ```
 
-In order to properly access Sentry by its configured hostname (`sentry.server` in the sentry.yml), you have to add this hostname to your hostsfile. On POSIX systems (Linx & OS X), you can add it by doing:
+In order to properly access Sentry by its configured hostname (`sentry.server`
+in the `sentry.yml`), you have to add this hostname to your hostsfile.
+On POSIX systems (Linux & OS X), you can add it by doing:
 
 ```
 $ sudo echo "<servername> 192.168.33.10" >> /etc/hosts
@@ -31,19 +46,32 @@ $ sudo echo "<servername> 192.168.33.10" >> /etc/hosts
 
 ## Different OSes
 
-By default, the Vagrant box runs Ubuntu 12.04, but the playbook supports Debian 7 and CentOS 6.4 as well! To try those out, uncomment the appropriate lines in the Vagrantfile and comment out the Debian lines.
+By default, the Vagrant box runs Ubuntu 12.04, but the playbook supports Debian
+7 and CentOS 6.4 as well! To try those out, uncomment the appropriate lines in
+the Vagrantfile and comment out the Debian lines.
 
 ## Using the playbook standalone
 
-You can of course also use the playbook without Vagrant. In that case you must provide your own inventory file specifying the host on which to install Sentry. The playbook has been tested on Ubuntu 12.04, Debian 7 and CentOS 6.4. Other flavors of Linux might work as well.
+You can of course also use the playbook without Vagrant. In that case you must
+provide your own inventory file specifying the host on which to install Sentry.
+The playbook has been tested on Ubuntu 12.04, Debian 7 and CentOS 6.4. Other
+flavors of Linux might work as well.
 
 ## Secret key
 
-On production environments you will want to set the ``secret_key`` setting under the ``sentry`` namespace to a unique key that acts as a signing token. Generate a secret key for [here](http://www.miniwebtool.com/django-secret-key-generator/)
+On production environments you will want to set the `secret_key` setting under
+the `sentry` namespace to a unique key that acts as a signing token. Generate a
+secret key for [here](http://www.miniwebtool.com/django-secret-key-generator/).
 
 ## Sending mail
 
-There's currently no Mail Transfer Agent being installed, like `postfix`. To enable sending mails anyways, you can use an external mail service that supports sending mail through SMTP. One such service is [Mailgun](http://www.mailgun.com), which allows sending up to 10,000 mails per month for free. To enable mail for sentry, you can edit your Sentry config (`/var/sentry/sentry_conf.py`) and add these variables:
+There's currently no Mail Transfer Agent being installed, like `postfix`.
+To enable sending mails anyways, you can use an external mail service that
+supports sending mail through SMTP. One such service is
+[Mailgun](http://www.mailgun.com), which allows sending up to 10,000 mails per
+month for free.
+To enable mail for sentry, you can edit your Sentry config
+(`/var/sentry/sentry_conf.py`) and add these variables:
 
 ```
 EMAIL_HOST = 'YOUR SMTP HOST'
@@ -56,11 +84,20 @@ SERVER_EMAIL = 'EMAIL ADDRESS MAILS SHOULD ORIGINATE FROM' # eg. sentry@mysentry
 
 ## Known issues / TODO
 
-* Sending mails is currently only possible through external services like Mailgun. Possibly install `postfix` for this purpose.
-* Unlike the [Puppet version](https://github.com/DandyDev/sentry-vagrant), this version does not require any manual steps. The one major drawback is that it's not completely idempotent. If you run it twice, the creation of the superuser will throw an error because it already exists.
+* Sending mails is currently only possible through external services like Mailgun.
+  Possibly install `postfix` for this purpose.
+* Unlike the [Puppet version](https://github.com/DandyDev/sentry-vagrant), this
+  version does not require any manual steps. The one major drawback is that
+  it's not completely idempotent. If you run it twice, the creation of the
+  superuser will throw an error because it already exists.
 * This hasn't been tested on other Providers than VirtualBox yet
-* On CentOS, the firewall is completely closed by default (at least on the box I tried it with). So you have to manually open the relevant port (80) using `iptables`, or if you're not concerned about security (because you're running it locally through Vagrant), you can always flush the firewall with `iptables -F`.
+* On CentOS, the firewall is completely closed by default (at least on the box
+  I tried it with).
+  So you have to manually open the relevant port (80) using `iptables`, or if
+  you're not concerned about security (because you're running it locally
+  through Vagrant), you can always flush the firewall with `iptables -F`.
 
 ## Contribute
 
-If you have any suggestions, feel free to create an issue here on Github and/or fork this repo, make changes and submit a pull request!
+If you have any suggestions, feel free to create an issue here on Github and/or
+fork this repo, make changes and submit a pull request!

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ in the `sentry.yml`), you have to add this hostname to your hostsfile.
 On POSIX systems (Linux & OS X), you can add it by doing:
 
 ```
-$ sudo echo "<servername> 192.168.33.10" >> /etc/hosts
+$ sudo echo "192.168.33.10 <servername>" >> /etc/hosts
 ```
 
 ## Different OSes

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ You also need to [install Ansible](http://docs.ansible.com/intro_installation.ht
 You can configure your install by modifying the variables in the `sentry.yml`
 file before provisioning.
 
+Note that postgresql may fail to install correctly unless you specify a
+compatible locale. 
+See https://github.com/ansible/ansible/issues/10698 for some background
+(ansible forwards the local environment unless you stop it).
+
 Then: 
 
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,13 +6,27 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define "sentry" do |sentry|
-    # sentry.vm.box = "centos-6-4"
-    # sentry.vm.box_url = "https://dl.dropboxusercontent.com/s/z85s74gv74m6flo/centos-6-4.box"
-    # sentry.vm.box = "wheezy64"
-    # sentry.vm.box_url = "https://dl.dropboxusercontent.com/s/j887m9989t2g8zj/wheezy64.box"
-    sentry.vm.box = "precise32"
-    sentry.vm.box_url = "http://files.vagrantup.com/precise32.box"
-    sentry.vm.network :private_network, ip: "192.168.33.10"
+    sentry.vm.box = "digital_ocean"
+    ENV['LC_ALL']="en_US.UTF-8"
+    ENV['LC_ADDRESS']="en_US.UTF-8"
+    ENV['LC_MEASUREMENT']="en_US.UTF-8"
+    ENV['LC_NUMERIC']="en_US.UTF-8"
+    ENV['LC_ALL']="en_US.UTF-8"
+    ENV['LC_MONETARY']="en_US.UTF-8"
+    ENV['LC_PAPER']="en_US.UTF-8"
+    ENV['LC_IDENTIFICATION']="en_US.UTF-8"
+    ENV['LC_NAME']="en_US.UTF-8"
+    ENV['LC_TELEPHONE']="en_US.UTF-8"
+
+    sentry.ssh.private_key_path = "redacted"
+    sentry.vm.provider :digital_ocean do |provider, override|
+      override.ssh.private_key_path = 'redacted'
+      provider.client_id = "getsentry"
+      provider.token = "redacted"
+      provider.image = "ubuntu-12-04-x64"
+      provider.region = "nyc2"
+      provider.size = "1gb"
+    end
 
     sentry.vm.provision "ansible" do |ansible| 
       ansible.playbook = "sentry.yml"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -26,6 +26,7 @@
     - libffi-dev
     - libssl-dev
     - libjpeg-dev
+    - redis-server
     - python-psycopg2
     - python-pip
     - memcached

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -14,6 +14,16 @@
   yum: pkg=/tmp/epel-release.rpm state=installed
   when: ansible_os_family == 'RedHat'
 
+- name: add pycurl for apt_repository to work
+  apt: name=python-pycurl
+  when: ansible_os_family == "Debian"
+
+- name: add PPA for redis
+  apt_repository: 
+    # This will fail unless Ubuntu ...
+    repo: ppa:chris-lea/redis-server 
+  when: ansible_os_family == "Debian"
+
 - name: install common packages debian/ubuntu
   apt: pkg={{ item }} state=latest
   with_items:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -25,6 +25,7 @@
     - libz-dev
     - libffi-dev
     - libssl-dev
+    - libjpeg-dev
     - python-psycopg2
     - python-pip
     - memcached

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: update apt package cache
-  apt: update_cache=yes
+  apt: update_cache=yes cache_valid_time=3600
   when: ansible_os_family == "Debian"
 
 - name: get epel-repo rpm RHEL6

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -14,7 +14,7 @@
   when: ansible_os_family == "RedHat"
 
 - name: Install the nginx packages 
-  apt: name={{ item }} state=present update_cache=yes
+  apt: name={{ item }} state=present update_cache=yes cache_valid_time=3600
   with_items: ubuntu_pkg
   environment: env
   when: ansible_os_family == "Debian"

--- a/roles/sentry/tasks/main.yml
+++ b/roles/sentry/tasks/main.yml
@@ -25,6 +25,13 @@
 - name: install sentry and create virtualenv if needed
   pip:
     name: sentry[postgres]
+    version: 8.5.1
+    virtualenv: /var/sentry/ve
+
+- name: install celery with redis
+  pip:
+    name: celery[redis]
+    version: 3.1.19
     virtualenv: /var/sentry/ve
     virtualenv_site_packages: no
 

--- a/roles/sentry/tasks/main.yml
+++ b/roles/sentry/tasks/main.yml
@@ -2,35 +2,67 @@
 
 - name: ensure sentry directory exists
   file:
-    path: /var/sentry/
+    path: /var/sentry
     state: directory
+
+# from https://www.stavros.io/posts/example-provisioning-and-deployment-ansible/
+# START
+- name: Create user.
+  user:
+      home: /var/sentry/home/
+      name: sentry
+      state: present
+
+- name: Update the project directory.
+  file:
+      group: sentry
+      owner: sentry
+      mode: 755
+      state: directory
+      path: /var/sentry
+# END
 
 - name: install sentry and create virtualenv if needed
   pip:
     name: sentry[postgres]
     virtualenv: /var/sentry/ve
     virtualenv_site_packages: no
-    
+
 - name: install memcached
   pip:
     name: python-memcached
     virtualenv: /var/sentry/ve
     virtualenv_site_packages: no
-    
+
 - name: Copy sentry configuration
-  template: src=sentry_conf.py.j2 dest=/var/sentry/sentry_conf.py
+  template:
+    src: sentry_conf.py.j2 
+    dest: /var/sentry/sentry_conf.py
+    owner: sentry
+    group: sentry
   notify: restart nginx
 
 - name: Copy nginx configuration for sentry
-  template: src=nginx-sentry.conf.j2 dest=/etc/nginx/sites-available/sentry.conf owner={{ nginx_user }} group={{ nginx_group }}
+  template: 
+    src: nginx-sentry.conf.j2 
+    dest: /etc/nginx/sites-available/sentry.conf 
+    owner: "{{ nginx_user }}" 
+    group: "{{ nginx_group }}"
 
 - name: Link nginx configuration for sentry
-  file: src=/etc/nginx/sites-available/sentry.conf dest=/etc/nginx/sites-enabled/sentry.conf state=link owner={{ nginx_user }} group={{ nginx_group }}
+  file: 
+    src: /etc/nginx/sites-available/sentry.conf 
+    dest: /etc/nginx/sites-enabled/sentry.conf 
+    state: link 
+    owner: "{{ nginx_user }}" 
+    group: "{{ nginx_group }}"
   notify:
     - restart nginx
 
 - name: Copy supervisor configuration for sentry
-  template: src=supervisor-sentry.conf.j2 dest=/etc/supervisor/conf.d/sentry.conf
+  template: 
+    src: supervisor-sentry.conf.j2 
+    dest: /etc/supervisor/conf.d/sentry.conf
   notify: 
     - reload supervisor
 
@@ -40,11 +72,12 @@
   notify:
     - restart nginx
     - reload supervisor
+
 # This is a bit of a hack to create a superuser automatically without interactive input. TODO: Create a proper python script for this!
 - name: create admin user
   action: shell source ve/bin/activate && export SENTRY_CONF=/var/sentry/sentry_conf.py && python -c "from sentry.utils.runner import configure; configure(); from django.db import DEFAULT_DB_ALIAS as database; from sentry.models import User; User.objects.db_manager(database).create_superuser('{{ superuser_sentry.username }}', '{{ superuser_sentry.email }}', '{{ superuser_sentry.password }}')" executable=/bin/bash chdir=/var/sentry
   notify:
     - restart nginx
     - reload supervisor
-    
+
 - shell: sudo service nginx restart && killall supervisord && sudo supervisord

--- a/roles/sentry/tasks/main.yml
+++ b/roles/sentry/tasks/main.yml
@@ -33,13 +33,11 @@
     name: celery[redis]
     version: 3.1.19
     virtualenv: /var/sentry/ve
-    virtualenv_site_packages: no
 
 - name: install memcached
   pip:
     name: python-memcached
     virtualenv: /var/sentry/ve
-    virtualenv_site_packages: no
 
 - name: Copy sentry configuration
   template:
@@ -87,4 +85,4 @@
     - restart nginx
     - reload supervisor
 
-- shell: sudo service nginx restart && killall supervisord && sudo supervisord
+- shell: sudo service nginx stop && sleep 3 && sudo service nginx start && sudo service supervisor stop && sudo service supervisor start

--- a/roles/sentry/templates/sentry_conf.py.j2
+++ b/roles/sentry/templates/sentry_conf.py.j2
@@ -45,6 +45,13 @@ SENTRY_OPTIONS["redis.clusters"] = {
     }
 }
 
+SENTRY_OPTIONS['mail.from'] = '{{ sentry_mail.username }}'
+SENTRY_OPTIONS['mail.host'] = '{{ sentry_mail.host }}'
+SENTRY_OPTIONS['mail.port'] = {{ sentry_mail.port }}
+SENTRY_OPTIONS['mail.username'] = '{{ sentry_mail.username }}'
+SENTRY_OPTIONS['mail.password'] = '{{ sentry_mail.password }}'
+SENTRY_OPTIONS['mail.use-tls'] = {{ sentry_mail.use_tls }}
+
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',

--- a/roles/sentry/templates/sentry_conf.py.j2
+++ b/roles/sentry/templates/sentry_conf.py.j2
@@ -4,6 +4,11 @@ from sentry.conf.server import *
 
 ROOT = os.path.dirname(__file__)
 
+INSTALLED_APPS = (
+    "south",
+    "kombu.transport.django",
+)
+
 DATABASES = {
     'default': {
         # You can swap out the engine for MySQL easily by changing this value

--- a/roles/sentry/templates/sentry_conf.py.j2
+++ b/roles/sentry/templates/sentry_conf.py.j2
@@ -18,8 +18,6 @@ DATABASES = {
     }
 }
 
-SENTRY_KEY = '{{ sentry.secret_key }}'
-
 # Set this to false to require authentication
 SENTRY_PUBLIC = False
 
@@ -33,6 +31,7 @@ ALLOWED_HOSTS = ['{{ sentry.server }}']
 SENTRY_LOGIN_URL = '{{ sentry.url }}/login/'
 
 SENTRY_OPTIONS['system.url-prefix'] = '{{ sentry.url }}'
+SENTRY_OPTIONS['system.secret-key'] = '{{ sentry.secret_key }}'
 SENTRY_OPTIONS["redis.clusters"] = {
     'default': {
         'hosts': {

--- a/roles/sentry/templates/sentry_conf.py.j2
+++ b/roles/sentry/templates/sentry_conf.py.j2
@@ -4,11 +4,6 @@ from sentry.conf.server import *
 
 ROOT = os.path.dirname(__file__)
 
-INSTALLED_APPS = (
-    "south",
-    "kombu.transport.django",
-)
-
 DATABASES = {
     'default': {
         # You can swap out the engine for MySQL easily by changing this value

--- a/roles/sentry/templates/sentry_conf.py.j2
+++ b/roles/sentry/templates/sentry_conf.py.j2
@@ -23,21 +23,23 @@ SENTRY_KEY = '{{ sentry.secret_key }}'
 # Set this to false to require authentication
 SENTRY_PUBLIC = False
 
-SENTRY_ALLOW_REGISTRATION = False
+SENTRY_FEATURES['auth:register'] = False
 
 SENTRY_WEB_HOST = '0.0.0.0'
 SENTRY_WEB_PORT = 9000
 
 ALLOWED_HOSTS = ['{{ sentry.server }}']
 
-SENTRY_URL_PREFIX = '{{ sentry.url }}'
 SENTRY_LOGIN_URL = '{{ sentry.url }}/login/'
 
-SENTRY_REDIS_OPTIONS = {
-    'hosts': {
-        0: {
-            'host': '127.0.0.1',
-            'port': 6379,
+SENTRY_OPTIONS['system.url-prefix'] = '{{ sentry.url }}'
+SENTRY_OPTIONS["redis.clusters"] = {
+    'default': {
+        'hosts': {
+            0: {
+                'host': '127.0.0.1',
+                'port': 6379,
+            }
         }
     }
 }

--- a/roles/sentry/templates/sentry_conf.py.j2
+++ b/roles/sentry/templates/sentry_conf.py.j2
@@ -18,6 +18,8 @@ DATABASES = {
     }
 }
 
+BROKER_URL = "redis://"
+
 # Set this to false to require authentication
 SENTRY_PUBLIC = False
 

--- a/roles/sentry/templates/supervisor-sentry.conf.j2
+++ b/roles/sentry/templates/supervisor-sentry.conf.j2
@@ -9,9 +9,8 @@ redirect_stderr=true
 
 # See https://docs.getsentry.com/on-premise/server/installation/#configure-supervisord
 [program:celery_beat]
-user=sentry
-group=sentry
-command=/var/sentry/ve/bin/sentry --config=/var/sentry/sentry_conf.py run cron --pidfile=$HOME/celerybeat.pid
+# command=/var/sentry/ve/bin/sentry --config=/var/sentry/sentry_conf.py run cron --pidfile=$HOME/celerybeat.pid
+command=/var/sentry/ve/bin/sentry --config=/var/sentry/sentry_conf.py run cron --pidfile=/var/sentry/home/celerybeat.pid
 environment=PATH="/var/sentry/ve/bin",HOME="/var/sentry/home",USER="sentry"
 autostart=true
 autorestart=true

--- a/roles/sentry/templates/supervisor-sentry.conf.j2
+++ b/roles/sentry/templates/supervisor-sentry.conf.j2
@@ -1,6 +1,27 @@
 [program:sentry]
+user=sentry
+group=sentry
 command=/var/sentry/ve/bin/sentry --config=/var/sentry/sentry_conf.py start http
-environment=PATH="/var/sentry/ve/bin"
+environment=PATH="/var/sentry/ve/bin",HOME="/home/sentry",USER="sentry"
+autostart=true
+autorestart=true
+redirect_stderr=true
+
+# See https://docs.getsentry.com/on-premise/server/installation/#configure-supervisord
+[program:celery_beat]
+user=sentry
+group=sentry
+command=/var/sentry/ve/bin/sentry --config=/var/sentry/sentry_conf.py celery beat --pidfile=$HOME/celerybeat.pid
+environment=PATH="/var/sentry/ve/bin",HOME="/home/sentry",USER="sentry"
+autostart=true
+autorestart=true
+redirect_stderr=true
+
+[program:celery_worker]
+user=sentry
+group=sentry
+command=/var/sentry/ve/bin/sentry --config=/var/sentry/sentry_conf.py celery worker
+environment=PATH="/var/sentry/ve/bin",HOME="/home/sentry",USER="sentry"
 autostart=true
 autorestart=true
 redirect_stderr=true

--- a/roles/sentry/templates/supervisor-sentry.conf.j2
+++ b/roles/sentry/templates/supervisor-sentry.conf.j2
@@ -2,7 +2,7 @@
 user=sentry
 group=sentry
 command=/var/sentry/ve/bin/sentry --config=/var/sentry/sentry_conf.py start http
-environment=PATH="/var/sentry/ve/bin",HOME="/home/sentry",USER="sentry"
+environment=PATH="/var/sentry/ve/bin",HOME="/var/sentry/home",USER="sentry"
 autostart=true
 autorestart=true
 redirect_stderr=true
@@ -11,8 +11,8 @@ redirect_stderr=true
 [program:celery_beat]
 user=sentry
 group=sentry
-command=/var/sentry/ve/bin/sentry --config=/var/sentry/sentry_conf.py celery beat --pidfile=$HOME/celerybeat.pid
-environment=PATH="/var/sentry/ve/bin",HOME="/home/sentry",USER="sentry"
+command=/var/sentry/ve/bin/sentry --config=/var/sentry/sentry_conf.py run cron --pidfile=$HOME/celerybeat.pid
+environment=PATH="/var/sentry/ve/bin",HOME="/var/sentry/home",USER="sentry"
 autostart=true
 autorestart=true
 redirect_stderr=true
@@ -21,7 +21,7 @@ redirect_stderr=true
 user=sentry
 group=sentry
 command=/var/sentry/ve/bin/sentry --config=/var/sentry/sentry_conf.py celery worker
-environment=PATH="/var/sentry/ve/bin",HOME="/home/sentry",USER="sentry"
+environment=PATH="/var/sentry/ve/bin",HOME="/var/sentry/home",USER="sentry"
 autostart=true
 autorestart=true
 redirect_stderr=true

--- a/sentry.yml
+++ b/sentry.yml
@@ -4,15 +4,15 @@
     db_sentry:
       name: sentry
       user: sentry
-      password: sentry
+      password: redacted
     superuser_sentry:
       username: admin
-      email: admin@example.com
-      password: admin
+      email: redacted
+      password: redacted
     sentry:
-      server: sentry.local
-      url: http://sentry.local
-      secret_key: 'my69eAMYjzqtmfaRJ107MeXCYDTaxQdNZPr8YOf/zOV5pIUoZa5biA=='
+      server: redacted
+      url: redacted
+      secret_key: 'redacted'
   roles:
     - common
     - python

--- a/sentry.yml
+++ b/sentry.yml
@@ -13,6 +13,12 @@
       server: redacted
       url: redacted
       secret_key: 'redacted'
+    sentry_mail:
+      host: localhost
+      port: 25
+      username: ''
+      password: ''
+      use_tls: false
   roles:
     - common
     - python


### PR DESCRIPTION
WIP, not for merge yet. 

It looks like everything works, but finally starting celery fails with an error on `djkombu_queue`.

```
(ve) $ sentry --config=/var/sentry/sentry_conf.py celery beat --pidfile=$HOME/celerybeat.pid

celery beat v3.1.18 (Cipater) is starting.
__    -    ... __   -        _
Configuration ->
    . broker -> django://localhost//
    . loader -> celery.loaders.app.AppLoader
    . scheduler -> celery.beat.PersistentScheduler
    . db -> /tmp/sentry-celerybeat
    . logfile -> [stderr]@%INFO
    . maxinterval -> now (0s)
[2016-05-08 08:22:15,052: INFO/MainProcess] beat: Starting...
[2016-05-08 08:22:15,085: INFO/MainProcess] Scheduler: Sending due task flush-buffers (sentry.tasks.process_buffer.process_pending)
[2016-05-08 08:22:15,137: ERROR/MainProcess] Message Error: Couldn't apply scheduled task flush-buffers: relation "djkombu_queue" does not exist
LINE 1: ..."djkombu_queue"."id", "djkombu_queue"."name" FROM "djkombu_q...
                                                             ^

['  File "/var/sentry/ve/bin/sentry", line 11, in <module>\n    sys.exit(main())\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/sentry/runner/__init__.py", line 148, in main\n    cli(prog_name=get_prog(), obj={}, max_content_width=100)\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/click/core.py", line 716, in __call__\n    return self.main(*args, **kwargs)\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/click/core.py", line 696, in main\n    rv = self.invoke(ctx)\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/click/core.py", line 1060, in invoke\n    return _process_result(sub_ctx.command.invoke(sub_ctx))\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/click/core.py", line 889, in invoke\n    return ctx.invoke(self.callback, **ctx.params)\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/click/core.py", line 534, in invoke\n    return callback(*args, **kwargs)\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func\n    return f(get_current_context(), *args, **kwargs)\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/sentry/runner/__init__.py", line 83, in inner\n    ctx.forward(django)\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/click/core.py", line 552, in forward\n    return self.invoke(cmd, **kwargs)\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/click/core.py", line 534, in invoke\n    return callback(*args, **kwargs)\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func\n    return f(get_current_context(), *args, **kwargs)\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/sentry/runner/decorators.py", line 26, in inner\n    return ctx.invoke(f, *args, **kwargs)\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/click/core.py", line 534, in invoke\n    return callback(*args, **kwargs)\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func\n    return f(get_current_context(), *args, **kwargs)\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/sentry/runner/commands/django.py", line 23, in django\n    execute_from_command_line(argv=[ctx.command_path] + list(management_args))\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 399, in execute_from_command_line\n    utility.execute()\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 392, in execute\n    self.fetch_command(subcommand).run_from_argv(self.argv)\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/sentry/management/commands/celery.py", line 24, in run_from_argv\n    [\'{0[0]} {0[1]}\'.format(argv)] + argv[2:],\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/celery/bin/celery.py", line 769, in execute_from_commandline\n    super(CeleryCommand, self).execute_from_commandline(argv)))\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/celery/bin/base.py", line 311, in execute_from_commandline\n    return self.handle_argv(self.prog_name, argv[1:])\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/celery/bin/celery.py", line 761, in handle_argv\n    return self.execute(command, argv)\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/celery/bin/celery.py", line 693, in execute\n    ).run_from_argv(self.prog_name, argv[1:], command=argv[0])\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/celery/bin/base.py", line 315, in run_from_argv\n    sys.argv if argv is None else argv, command)\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/celery/bin/base.py", line 377, in handle_argv\n    return self(*args, **options)\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/celery/bin/base.py", line 274, in __call__\n    ret = self.run(*args, **kwargs)\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/celery/bin/beat.py", line 79, in run\n    return beat().run()\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/celery/apps/beat.py", line 83, in run\n    self.start_scheduler()\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/celery/apps/beat.py", line 112, in start_scheduler\n    beat.start()\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/celery/beat.py", line 463, in start\n    interval = self.scheduler.tick()\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/celery/beat.py", line 221, in tick\n    next_time_to_run = self.maybe_due(entry, self.publisher)\n', '  File "/var/sentry/ve/local/lib/python2.7/site-packages/celery/beat.py", line 207, in maybe_due\n    exc, traceback.format_stack(), exc_info=True)\n']
Traceback (most recent call last):
  File "/var/sentry/ve/local/lib/python2.7/site-packages/celery/beat.py", line 204, in maybe_due
    result = self.apply_async(entry, publisher=publisher)
  File "/var/sentry/ve/local/lib/python2.7/site-packages/celery/beat.py", line 260, in apply_async
    entry, exc=exc)), sys.exc_info()[2])
  File "/var/sentry/ve/local/lib/python2.7/site-packages/celery/beat.py", line 252, in apply_async
    **entry.options)
  File "/var/sentry/ve/local/lib/python2.7/site-packages/sentry/celery.py", line 44, in apply_async
    return OriginalTask.apply_async(self, *args, **kwargs)
  File "/var/sentry/ve/local/lib/python2.7/site-packages/celery/app/task.py", line 559, in apply_async
    **dict(self._get_exec_options(), **options)
  File "/var/sentry/ve/local/lib/python2.7/site-packages/celery/app/base.py", line 353, in send_task
    reply_to=reply_to or self.oid, **options
  File "/var/sentry/ve/local/lib/python2.7/site-packages/celery/app/amqp.py", line 305, in publish_task
    **kwargs
  File "/var/sentry/ve/local/lib/python2.7/site-packages/kombu/messaging.py", line 172, in publish
    routing_key, mandatory, immediate, exchange, declare)
  File "/var/sentry/ve/local/lib/python2.7/site-packages/kombu/connection.py", line 436, in _ensured
    return fun(*args, **kwargs)
  File "/var/sentry/ve/local/lib/python2.7/site-packages/kombu/messaging.py", line 184, in _publish
    [maybe_declare(entity) for entity in declare]
  File "/var/sentry/ve/local/lib/python2.7/site-packages/kombu/messaging.py", line 111, in maybe_declare
    return maybe_declare(entity, self.channel, retry, **retry_policy)
  File "/var/sentry/ve/local/lib/python2.7/site-packages/kombu/common.py", line 113, in maybe_declare
    return _maybe_declare(entity, declared, ident, channel)
  File "/var/sentry/ve/local/lib/python2.7/site-packages/kombu/common.py", line 120, in _maybe_declare
    entity.declare()
  File "/var/sentry/ve/local/lib/python2.7/site-packages/kombu/entity.py", line 522, in declare
    self.queue_declare(nowait, passive=False)
  File "/var/sentry/ve/local/lib/python2.7/site-packages/kombu/entity.py", line 548, in queue_declare
    nowait=nowait)
  File "/var/sentry/ve/local/lib/python2.7/site-packages/kombu/transport/virtual/__init__.py", line 446, in queue_declare
    self._new_queue(queue, **kwargs)
  File "/var/sentry/ve/local/lib/python2.7/site-packages/kombu/transport/django/__init__.py", line 36, in _new_queue
    self.Queue.objects.get_or_create(name=queue)
  File "/var/sentry/ve/local/lib/python2.7/site-packages/django/db/models/manager.py", line 154, in get_or_create
    return self.get_queryset().get_or_create(**kwargs)
  File "/var/sentry/ve/local/lib/python2.7/site-packages/django/db/models/query.py", line 376, in get_or_create
    return self.get(**lookup), False
  File "/var/sentry/ve/local/lib/python2.7/site-packages/django/db/models/query.py", line 304, in get
    num = len(clone)
  File "/var/sentry/ve/local/lib/python2.7/site-packages/django/db/models/query.py", line 77, in __len__
    self._fetch_all()
  File "/var/sentry/ve/local/lib/python2.7/site-packages/django/db/models/query.py", line 857, in _fetch_all
    self._result_cache = list(self.iterator())
  File "/var/sentry/ve/local/lib/python2.7/site-packages/django/db/models/query.py", line 220, in iterator
    for row in compiler.results_iter():
  File "/var/sentry/ve/local/lib/python2.7/site-packages/django/db/models/sql/compiler.py", line 713, in results_iter
    for rows in self.execute_sql(MULTI):
  File "/var/sentry/ve/local/lib/python2.7/site-packages/django/db/models/sql/compiler.py", line 786, in execute_sql
    cursor.execute(sql, params)
  File "/var/sentry/ve/local/lib/python2.7/site-packages/django/db/backends/util.py", line 53, in execute
    return self.cursor.execute(sql, params)
  File "/var/sentry/ve/local/lib/python2.7/site-packages/django/db/utils.py", line 99, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "/var/sentry/ve/local/lib/python2.7/site-packages/django/db/backends/util.py", line 53, in execute
    return self.cursor.execute(sql, params)
SchedulingError: Couldn't apply scheduled task flush-buffers: relation "djkombu_queue" does not exist
LINE 1: ..."djkombu_queue"."id", "djkombu_queue"."name" FROM "djkombu_q...
```
